### PR TITLE
Add some common types

### DIFF
--- a/src/clerk/types/Email.hx
+++ b/src/clerk/types/Email.hx
@@ -1,0 +1,9 @@
+package clerk.types;
+
+abstract Email(String) to String {
+  static var regex = ~/^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i; // http://try.haxe.org/#0B65c
+  @:from static function ofString(s:String):Email
+    return 
+      if (regex.match(s)) cast s;
+      else throw 'Invalid email "$s"';
+}

--- a/src/clerk/types/MinLength.hx
+++ b/src/clerk/types/MinLength.hx
@@ -1,0 +1,53 @@
+package clerk.types;
+
+#if !macro
+@:genericBuild(clerk.types.MinLength.build())
+class MinLength<Rest> {}
+#else
+
+import tink.macro.BuildCache;
+import haxe.macro.Expr;
+import haxe.macro.Type;
+using tink.MacroApi;
+
+class MinLength {
+  public static function build() {
+    return BuildCache.getTypeN('clerk.types.MinLength', function(ctx:BuildContextN) {
+      var name = ctx.name;
+      var pack = ['clerk', 'types'];
+      var ct = TPath(pack.concat([name]).join('.').asTypePath());
+      if(ctx.types.length > 2) ctx.pos.error('Too many type parameters, max is 2');
+      var length = getInt(ctx.types[0], ctx.pos);
+      var error = ctx.types.length == 2 ? getString(ctx.types[1], ctx.pos) : 'Too short, minimum length is $length';
+      
+      var def = macro class $name {
+        @:from
+        public static function ofString(s:String):$ct {
+          return 
+            if (s.length < $v{length}) throw $v{error};
+            else cast s;
+        }
+      }
+      def.pack = pack;
+      def.kind = TDAbstract(macro:String, [], [macro:String]);
+      def.pos = ctx.pos;
+      return def;
+    });
+  }
+  
+  static function getInt(type:Type, pos:Position) {
+    return switch type {
+      case TInst(_.get() => {kind: KExpr(macro $v{(i:Int)})}, _): Std.parseInt(i);
+      case _: pos.error('Expected type parameter to be a integer literal');
+    }
+  }
+  
+  static function getString(type:Type, pos:Position) {
+    return switch type {
+      case TInst(_.get() => {kind: KExpr(macro $v{(s:String)})}, _): s;
+      case _: pos.error('Expected type parameter to be a string literal');
+    }
+  }
+}
+
+#end

--- a/src/clerk/types/NotEmpty.hx
+++ b/src/clerk/types/NotEmpty.hx
@@ -1,0 +1,3 @@
+package clerk.types;
+
+typedef NotEmpty = MinLength<1, 'Should not be empty'>;

--- a/src/clerk/types/RegExp.hx
+++ b/src/clerk/types/RegExp.hx
@@ -1,0 +1,58 @@
+package clerk.types;
+
+#if !macro
+@:genericBuild(clerk.types.RegExp.build())
+class RegExp<Rest> {}
+#else
+
+import tink.macro.BuildCache;
+import haxe.macro.Expr;
+import haxe.macro.Type;
+using tink.MacroApi;
+
+class RegExp {
+  public static function build() {
+    return BuildCache.getTypeN('clerk.types.RegExp', function(ctx:BuildContextN) {
+      var name = ctx.name;
+      var pack = ['clerk', 'types'];
+      var ct = TPath(pack.concat([name]).join('.').asTypePath());
+      if(ctx.types.length > 2) ctx.pos.error('Too many type parameters, max is 2');
+      var regex = getRegExp(ctx.types[0], ctx.pos);
+      var error = 
+        if(ctx.types.length == 2)
+          macro $v{getString(ctx.types[1], ctx.pos)}
+        else 
+          macro 'Invalid value "' + s + $v{'" (should match ~/${regex.r}/${regex.opt})'};
+      
+      var def = macro class $name {
+        static var regex = new EReg($v{regex.r}, $v{regex.opt});
+        @:from
+        public static function ofString(s:String):$ct {
+          return 
+            if (regex.match(s)) cast s
+            else throw $error;
+        }
+      }
+      def.pack = pack;
+      def.kind = TDAbstract(macro:String, [], [macro:String]);
+      def.pos = ctx.pos;
+      return def;
+    });
+  }
+  
+  static function getRegExp(type:Type, pos:Position) {
+    return switch type {
+      case TInst(_.get() => {kind: KExpr({expr: EConst(CRegexp(r, opt))})}, _): {r: r, opt: opt};
+      case _: pos.error('Expected type parameter to be a regular expression literal');
+    }
+  }
+  
+  static function getString(type:Type, pos:Position) {
+    return switch type {
+      case TInst(_.get() => {kind: KExpr(macro $v{(s:String)})}, _): s;
+      case _: pos.error('Expected type parameter to be a string literal');
+    }
+  }
+}
+
+#end


### PR DESCRIPTION
For now I added: `Email`, `MinLength`, `NotEmpty` & `RegExp`

I will try to add some more (in later PRs) by referencing https://semantic-ui.com/behaviors/form.html#validation-rules